### PR TITLE
add route for updateDraftType

### DIFF
--- a/lib/api/mailSettings.js
+++ b/lib/api/mailSettings.js
@@ -57,10 +57,10 @@ export const updateViewMode = (ViewMode) => ({
     data: { ViewMode }
 });
 
-export const updateDraftType = (draftType) => ({
+export const updateDraftType = (MIMEType) => ({
     url: 'settings/mail/drafttype',
     method: 'put',
-    data: { draftType }
+    data: { MIMEType }
 });
 
 export const updateRightToLeft = (RightToLeft) => ({

--- a/lib/api/mailSettings.js
+++ b/lib/api/mailSettings.js
@@ -57,6 +57,12 @@ export const updateViewMode = (ViewMode) => ({
     data: { ViewMode }
 });
 
+export const updateDraftType = (draftType) => ({
+    url: 'settings/mail/drafttype',
+    method: 'put',
+    data: { draftType }
+});
+
 export const updateRightToLeft = (RightToLeft) => ({
     url: 'settings/mail/righttoleft',
     method: 'put',


### PR DESCRIPTION
I think the route Update Draft Type [/settings/mail/drafttype] from https://gitlab.protontech.ch/ProtonMail/Slim-API/blob/develop/api-spec/pm_api_mail_settings.md was missing in api/mailSettings.js