### PR TITLE
Add support for sending form data

### DIFF
--- a/lib/fetch/fetch.js
+++ b/lib/fetch/fetch.js
@@ -1,4 +1,4 @@
-import { createUrl, checkStatus } from './helpers';
+import { createUrl, checkStatus, serializeData } from './helpers';
 
 const fetchHelper = ({ url: urlString, params, output, ...rest }) => {
     const config = {
@@ -15,20 +15,16 @@ const fetchHelper = ({ url: urlString, params, output, ...rest }) => {
         .then((response) => response[output]());
 };
 
-export const fetchJson = ({ data, headers, output = 'json', ...config }) => {
-    const extraHeaders = data
-        ? {
-              'Content-Type': 'application/json'
-          }
-        : undefined;
+export default ({ data, headers, input = 'json', output = 'json', ...config }) => {
+    const { headers: dataHeaders, body } = serializeData(data, input);
 
     return fetchHelper({
         ...config,
         headers: {
             ...headers,
-            ...extraHeaders
+            ...dataHeaders
         },
-        body: data ? JSON.stringify(data) : undefined,
+        body,
         output
     });
 };

--- a/lib/fetch/helpers.js
+++ b/lib/fetch/helpers.js
@@ -1,3 +1,10 @@
+/**
+ * Create an API error.
+ * @param {Object} response - Full response object
+ * @param {any} data - Data received
+ * @param {Object} config - Config used
+ * @returns {Error}
+ */
 export const createApiError = (response, data, config) => {
     const error = new Error(response.statusText);
 
@@ -9,6 +16,12 @@ export const createApiError = (response, data, config) => {
     return error;
 };
 
+/**
+ * Append query parameters to a URL.
+ * This is to support URLs which already have query parameters.
+ * @param {String} url
+ * @param {Object} params
+ */
 const appendQueryParams = (url, params) => {
     Object.keys(params).forEach((key) => {
         const value = params[key];
@@ -19,12 +32,25 @@ const appendQueryParams = (url, params) => {
     });
 };
 
+/**
+ * Create a URL from a string and query parameters object.
+ * @param {String} urlString
+ * @param {Object} params
+ * @returns {URL}
+ */
 export const createUrl = (urlString, params = {}) => {
     const url = new URL(urlString);
     appendQueryParams(url, params);
     return url;
 };
 
+/**
+ * Merge headers for the request.
+ * @param {Object} configHeaders
+ * @param {Object} restConfig
+ * @param {Object} headers
+ * @returns {Object}
+ */
 export const mergeHeaders = ({ headers: configHeaders, ...restConfig }, headers) => ({
     ...restConfig,
     headers: {
@@ -33,6 +59,12 @@ export const mergeHeaders = ({ headers: configHeaders, ...restConfig }, headers)
     }
 });
 
+/**
+ * Check the status of the response, and throw if needed.
+ * @param {Object} response - Full response
+ * @param {Object} config - Used config
+ * @returns {Promise}
+ */
 export const checkStatus = (response, config) => {
     const { status } = response;
 
@@ -46,4 +78,46 @@ export const checkStatus = (response, config) => {
         .then((data) => {
             throw createApiError(response, data, config);
         });
+};
+
+/**
+ * Create FormData from an object
+ * @param {Object} data
+ * @returns {FormData}
+ */
+export const serializeFormData = (data) => {
+    const formData = new FormData();
+    Object.keys(data).forEach((key) => {
+        formData.append(key, data[key]);
+    });
+    return formData;
+};
+
+/**
+ * Serialize data and create the body and headers needed.
+ * @param {Object} data
+ * @param {String} input
+ * @returns {Object}
+ */
+export const serializeData = (data, input) => {
+    if (!data) {
+        return {};
+    }
+    if (input === 'json') {
+        return {
+            body: JSON.stringify(data),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        };
+    }
+    if (input === 'form') {
+        return {
+            body: serializeFormData(data),
+            headers: {
+                'Content-Type': undefined // By setting 'Content-Type': undefined, the browser sets the Content-Type to multipart/form-data for us and fills in the correct boundary. Manually setting 'Content-Type': multipart/form-data will fail to fill in the boundary parameter of the request.
+            }
+        };
+    }
+    return {};
 };

--- a/test/fetch/fetch.spec.js
+++ b/test/fetch/fetch.spec.js
@@ -1,0 +1,126 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import assert from 'assert';
+import performRequest from '../../lib/fetch/fetch';
+import { createSpy } from '../spy';
+
+class FormDataMock {
+    constructor() {
+        this.data = {};
+    }
+
+    append(name, key) {
+        this.data[name] = key;
+    }
+}
+
+describe('fetch', () => {
+    let preFetch;
+    let preFormData;
+
+    beforeEach(() => {
+        preFetch = global.fetch;
+        preFormData = global.FormData;
+        global.FormData = FormDataMock;
+    });
+
+    afterEach(() => {
+        global.fetch = preFetch;
+        global.FormData = preFormData;
+    });
+
+    const setup = (fn) => {
+        const spy = createSpy(fn);
+        global.fetch = spy;
+        return spy;
+    };
+
+    it('should be able to receive json data', async () => {
+        setup(async () => ({ json: async () => ({ bar: 1 }), status: 200 }));
+        const config = {
+            url: 'http://foo.com/'
+        };
+        const result = await performRequest(config);
+        assert.deepStrictEqual(result, { bar: 1 });
+    });
+
+    it('should be able to receive blob data', async () => {
+        setup(async () => ({ blob: async () => 123, status: 200 }));
+        const config = {
+            url: 'http://foo.com/',
+            output: 'blob'
+        };
+        const result = await performRequest(config);
+        assert.deepStrictEqual(result, 123);
+    });
+
+    it('should be able to send json data', async () => {
+        const spy = setup(async () => ({ json: async () => ({ bar: 1 }), status: 200 }));
+        const config = {
+            url: 'http://foo.com/',
+            data: {
+                foo: 'bar'
+            }
+        };
+        await performRequest(config);
+        assert.deepStrictEqual(spy.calls[0], [
+            new URL(config.url),
+            {
+                mode: 'cors',
+                credentials: 'include',
+                redirect: 'follow',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(config.data)
+            }
+        ]);
+    });
+
+    it('should be able to send form data', async () => {
+        const spy = setup(async () => ({ json: async () => ({ bar: 1 }), status: 200 }));
+        const config = {
+            url: 'http://foo.com/',
+            input: 'form',
+            data: {
+                foo: 'bar'
+            }
+        };
+        await performRequest(config);
+        const fd = new FormData();
+        fd.append('foo', 'bar');
+        assert.deepStrictEqual(spy.calls[0], [
+            new URL(config.url),
+            {
+                mode: 'cors',
+                credentials: 'include',
+                redirect: 'follow',
+                headers: {
+                    'Content-Type': undefined
+                },
+                body: fd
+            }
+        ]);
+    });
+
+    it('should throw on 400 error and include the config, data and status', async () => {
+        setup(async () => ({ json: async () => ({ bar: 1 }), status: 400 }));
+        const config = {
+            url: 'http://foo.com/',
+            suppress: [123]
+        };
+        await assert.rejects(performRequest(config), {
+            name: 'Error',
+            message: '',
+            status: 400,
+            data: { bar: 1 },
+            config: {
+                suppress: [123],
+                mode: 'cors',
+                credentials: 'include',
+                redirect: 'follow',
+                headers: {},
+                body: undefined
+            }
+        });
+    });
+});


### PR DESCRIPTION
Adds support for sending form data by adding a new `input` option (to have consistency with the `output`) option.

Example:

```
const config = {
    url: 'http://foo.com/',
    input: 'form',
    data: {
        foo: 'bar'
    }
};
```

which would serialise it with `FormData` and set the appropriate header.

It leaves 'json' as the default input for data serialisation.

Requires a small update in `react-components` since I changed the export