### PR TITLE
add SHOW_MOVED constant

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -168,6 +168,13 @@ export const VIEW_MODE = {
     SINGLE: 1
 };
 
+export const SHOW_MOVED = {
+    NONE: 0,
+    DRAFTS: 1,
+    SENT: 2,
+    DRAFTS_AND_SENT: 3
+};
+
 export const THEMES = {
     DARK: {
         label: c('Theme').t`Dark (Default)`,


### PR DESCRIPTION
In order to address https://github.com/ProtonMail/react-components/issues/72 we need this.

Also to be in line with the API specs: https://gitlab.protontech.ch/ProtonMail/Slim-API/blob/develop/api-spec/pm_api_mail_settings.md#update-show-moved-settingsmailmoved