### PR TITLE
set pagesize limit = 50 in queryContactExport route

### DIFF
--- a/lib/api/contacts.js
+++ b/lib/api/contacts.js
@@ -4,7 +4,7 @@ export const queryContacts = ({ Page = 0, PageSize = 1000, LabelID } = {}) => ({
     params: { Page, PageSize, LabelID }
 });
 
-export const queryContactExport = ({ Page = 0, PageSize = 1000, LabelID } = {}) => ({
+export const queryContactExport = ({ Page = 0, PageSize = 50, LabelID } = {}) => ({
     url: 'contacts/export',
     method: 'get',
     params: { Page, PageSize, LabelID }


### PR DESCRIPTION
The maximum number of contacts that we can get for export from the api is 50, as indicated in the api-specs https://gitlab.protontech.ch/ProtonMail/Slim-API/blob/develop/api-spec/pm_api_contacts.md#get-contact-export-contactsexportpagepagesizelabelid