### PR TITLE
fix wrong image resize computation

### DIFF
--- a/lib/helpers/image.js
+++ b/lib/helpers/image.js
@@ -29,7 +29,13 @@ export const toImage = (base64str) => {
  *
  * @dev If maxWidth or maxHeight are equal to zero, the corresponding dimension is ignored
  */
-export const resizeImage = (original, maxWidth, maxHeight, finalMimeType = 'image/jpeg', encoderOptions = 1) => {
+export const resizeImage = (
+    original,
+    maxWidth = 0,
+    maxHeight = 0,
+    finalMimeType = 'image/jpeg',
+    encoderOptions = 1
+) => {
     return toImage(original).then((image) => {
         // Resize the image
         const canvas = document.createElement('canvas');
@@ -43,6 +49,8 @@ export const resizeImage = (original, maxWidth, maxHeight, finalMimeType = 'imag
         } else if (heightRatio > 1) {
             width /= heightRatio;
             height = maxHeight;
+        } else {
+            return image.src;
         }
 
         canvas.width = width;

--- a/lib/helpers/image.js
+++ b/lib/helpers/image.js
@@ -19,26 +19,30 @@ export const toImage = (base64str) => {
 };
 
 /**
- * Resizes a picture to a maximum length/width (based on largest dimension)
+ * Resizes a picture to a maximum height/width (preserving height/width ratio)
  * @param {String} original Base64 representation of image to be resized.
- * @param {Number} maxSize Amount of pixels that largest dimention (whether width or length) should have.
+ * @param {Number} maxWidth Maximum amount of pixels for the width of the resized image.
+ * @param {Number} maxHeight Maximum amount of pixels for the height of the resized image
  * @param {String} finalMimeType Mime type of the resulting resized image.
  * @param {Number} encoderOptions A Number between 0 and 1 indicating image quality if the requested type is image/jpeg or image/webp
  * @return {Promise} receives base64 string of resized image.
+ *
+ * @dev If maxWidth or maxHeight are equal to zero, the corresponding dimension is ignored
  */
-export const resizeImage = (original, maxSize, finalMimeType = 'image/jpeg', encoderOptions = 1) => {
+export const resizeImage = (original, maxWidth, maxHeight, finalMimeType = 'image/jpeg', encoderOptions = 1) => {
     return toImage(original).then((image) => {
         // Resize the image
         const canvas = document.createElement('canvas');
-        let { width } = image;
-        let { height } = image;
+        let { width, height } = image;
 
-        if (width > height && width > maxSize) {
-            height *= maxSize / width;
-            width = maxSize;
-        } else if (height > maxSize) {
-            width *= maxSize / height;
-            height = maxSize;
+        const [widthRatio, heightRatio] = [maxWidth && width / maxWidth, maxHeight && height / maxHeight].map(Number);
+
+        if (widthRatio >= heightRatio && widthRatio > 1) {
+            height /= widthRatio;
+            width = maxWidth;
+        } else if (heightRatio > 1) {
+            width /= heightRatio;
+            height = maxHeight;
         }
 
         canvas.width = width;
@@ -99,25 +103,25 @@ export const toBlob = (base64str) => {
 /**
  * Down size image to reach the max size limit
  * @param  {String} base64str
- * @param  {} maxSize in bytes
+ * @param  {Number} maxSize in bytes
  * @param  {String} mimeType
  * @param  {Number} encoderOptions
  * @return {Promise}
  */
 export const downSize = (base64str, maxSize, mimeType = 'image/jpeg', encoderOptions = 1) => {
-    const process = (source, max) => {
-        return resizeImage(source, max, mimeType, encoderOptions).then((resized) => {
-            const { size } = toBlob(resized);
+    const process = (source, maxWidth, maxHeight) => {
+        return resizeImage(source, maxWidth, maxHeight, mimeType, encoderOptions).then((resized) => {
+            const { size } = new Blob([resized]);
 
             if (size <= maxSize) {
                 return resized;
             }
 
-            return process(resized, Math.round(max * 0.9));
+            return process(resized, Math.round(maxWidth * 0.9), Math.round(maxHeight * 0.9));
         });
     };
 
-    return toImage(base64str).then(({ height, width }) => process(base64str, height > width ? height : width));
+    return toImage(base64str).then(({ height, width }) => process(base64str, width, height));
 };
 
 /**

--- a/test/helpers/image.spec.js
+++ b/test/helpers/image.spec.js
@@ -1,5 +1,5 @@
 import { resizeImage, toBlob, toFile, formatImage } from '../../lib/helpers/image';
-import img from './file.data';
+import img from './file.data'; // width: 300 px, height: 200 px
 
 const MIMETYPE_REGEX = /data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*/;
 const fileName = 'proton';
@@ -30,33 +30,51 @@ describe('toFile', () => {
 
 describe('resizeImage', () => {
     it('it should be a string', async () => {
-        const base64str = await resizeImage(img, 100);
+        const base64str = await resizeImage(img, 100, 100);
 
         expect(typeof base64str).toBe('string');
     });
 
-    it('it should be shorter than the original', async () => {
-        const base64str = await resizeImage(img, 100);
+    it('it should be shorter than the original if resized', async () => {
+        const base64str = await resizeImage(img, 100, 100);
 
         expect(base64str.length).toBeLessThan(img.length);
     });
 
+    it('it should not be resized if the resize parameters coincide with the original image size', async () => {
+        const base64str = await resizeImage(img, 300, 200);
+
+        expect(base64str.length).toBe(img.length);
+    });
+
+    it('it should not be resized if the width resize parameters is bigger than the original and the height is ignored', async () => {
+        const base64str = await resizeImage(img, 900);
+
+        expect(base64str.length).toBe(img.length);
+    });
+
+    it('it should not be resized if the height resize parameters is bigger than the original and the width is ignored', async () => {
+        const base64str = await resizeImage(img, 0, 400);
+
+        expect(base64str.length).toBe(img.length);
+    });
+
     it('it should be a 64 string encoded', async () => {
-        const base64str = await resizeImage(img, 100);
+        const base64str = await resizeImage(img, 100, 100);
 
         expect(typeof window.atob(base64str.replace('data:image/jpeg;base64,', ''))).toBe('string');
     });
 
     it('it should be respect the MIMEType set', async () => {
-        const base64str = await resizeImage(img, 100, 'image/png');
+        const base64str = await resizeImage(img, 100, 0, 'image/png');
 
         expect(base64str.match(MIMETYPE_REGEX)[1]).toBe('image/png');
     });
 
     it('it should have a difference on image quality', async () => {
         const [base64str1, base64str2] = await Promise.all([
-            resizeImage(img, 100, 'image/jpeg', 1),
-            resizeImage(img, 100, 'image/jpeg', 0.1)
+            resizeImage(img, 100, 0, 'image/jpeg', 1),
+            resizeImage(img, 100, 0, 'image/jpeg', 0.1)
         ]);
 
         expect(base64str1.length).toBeGreaterThan(base64str2.length);


### PR DESCRIPTION
The function `resize` in image.js was doing a wrong size computation because of passing by some intermediate uint8Array (which measures differently that the corresponding base64 string), that is not needed.

Also some other small non-breaking changes.

Reviewed with @mmso 