### PR TITLE
Load sentry

### DIFF
--- a/lib/helpers/sentry.js
+++ b/lib/helpers/sentry.js
@@ -16,4 +16,6 @@ function main({ SENTRY_DSN, SENTRY_RELEASE, APP_VERSION }) {
     });
 }
 
+export const traceError = (e) => !document.URL.includes('localhost:') && Sentry.captureException(e);
+
 export default main;

--- a/lib/helpers/sentry.js
+++ b/lib/helpers/sentry.js
@@ -1,0 +1,19 @@
+import * as Sentry from '@sentry/browser';
+
+function main({ SENTRY_DSN, SENTRY_RELEASE, APP_VERSION }) {
+    // No need to configure it if we don't load the DSN
+    if (!SENTRY_DSN && document.URL.includes('localhost:')) {
+        return;
+    }
+
+    Sentry.init({
+        dsn: SENTRY_DSN,
+        release: SENTRY_RELEASE
+    });
+
+    Sentry.configureScope((scope) => {
+        scope.setTag('appVersion', APP_VERSION);
+    });
+}
+
+export default main;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/ProtonMail/proton-shared#readme",
   "dependencies": {
+    "@sentry/browser": "^5.6.2",
     "dayjs": "^1.8.8",
     "file-saver": "^2.0.2",
     "get-random-values": "github:ProtonMail/get-random-values#semver:^1.0.0",


### PR DESCRIPTION
Usage inside `App.js`

```js
import sentry from 'proton-shared/lib/helpers/sentry';
import * as config from './config';
[...]

sentry(config);
....

