### PR TITLE
Apply allowJs for subprojects

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "proton-shared",
   "version": "1.0.0",
   "description": "Proton shared",
-  "main": "lib/index.ts",
-  "module": "lib/module.js",
   "sideEffects": false,
   "scripts": {
     "test": "NODE_ENV=test karma start test/karma.conf.js",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,11 +9,11 @@
         "module": "esnext",
         "moduleResolution": "node",
         "resolveJsonModule": true,
-        "isolatedModules": true,
         "noUnusedLocals": true,
         "noEmit": true,
         "jsx": "preserve",
-        "allowJs": true
+        "allowJs": true,
+        "maxNodeModuleJsDepth": 2
     },
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
`maxNodeModuleJsDepth` is 0 by default, so allowJs flag was not working in submodules.

We want it to work from ts files in submodules, hence 2. 1 would be if we wanted to allowJs from ts files in main module only, 0 if we want all submodules to have typedefs.

🤞 it works when projects are back-referenced.