### PR TITLE
modify resizeImage function

### DIFF
--- a/lib/helpers/image.js
+++ b/lib/helpers/image.js
@@ -31,7 +31,7 @@ export const toImage = (base64str) => {
  *
  * @dev If maxWidth or maxHeight are equal to zero, the corresponding dimension is ignored
  */
-export const resizeImage = ({
+export const resizeImage = async ({
     original,
     maxWidth = 0,
     maxHeight = 0,
@@ -39,33 +39,31 @@ export const resizeImage = ({
     encoderOptions = 1,
     bigResize = false
 }) => {
-    return toImage(original).then((image) => {
-        // Resize the image
-        const canvas = document.createElement('canvas');
-        let { width, height } = image;
+    const image = await toImage(original);
+    // Resize the image
+    let { width, height } = image;
+    const canvas = document.createElement('canvas');
+    const [widthRatio, heightRatio] = [maxWidth && width / maxWidth, maxHeight && height / maxHeight].map(Number);
 
-        const [widthRatio, heightRatio] = [maxWidth && width / maxWidth, maxHeight && height / maxHeight].map(Number);
+    if (widthRatio <= 1 && heightRatio <= 1) {
+        return image.src;
+    }
 
-        if (widthRatio <= 1 && heightRatio <= 1) {
-            return image.src;
-        }
+    const invert = maxWidth && maxHeight && bigResize;
 
-        const invert = maxWidth && maxHeight && bigResize;
+    if (widthRatio >= heightRatio === !invert) {
+        height /= widthRatio;
+        width = maxWidth;
+    } else {
+        width /= heightRatio;
+        height = maxHeight;
+    }
 
-        if (widthRatio >= heightRatio === !invert) {
-            height /= widthRatio;
-            width = maxWidth;
-        } else {
-            width /= heightRatio;
-            height = maxHeight;
-        }
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getContext('2d').drawImage(image, 0, 0, width, height);
 
-        canvas.width = width;
-        canvas.height = height;
-        canvas.getContext('2d').drawImage(image, 0, 0, width, height);
-
-        return canvas.toDataURL(finalMimeType, encoderOptions);
-    });
+    return canvas.toDataURL(finalMimeType, encoderOptions);
 };
 
 /**
@@ -73,7 +71,7 @@ export const resizeImage = ({
  * @param {String} str
  * @returns {Promise} {mime, base64}
  */
-export const extractBase64Image = (str = '') => {
+const extractBase64Image = (str = '') => {
     const [mimeInfo = '', base64 = ''] = (str || '').split(',');
     const [, mime = ''] = mimeInfo.match(/:(.*?);/) || [];
     return { mime, base64 };
@@ -123,22 +121,26 @@ export const toBlob = (base64str) => {
  * @param  {Number} encoderOptions
  * @return {Promise}
  */
-export const downSize = (base64str, maxSize, mimeType = 'image/jpeg', encoderOptions = 1) => {
-    const process = (source, maxWidth, maxHeight) => {
-        return resizeImage({ original: source, maxWidth, maxHeight, finalMimeType: mimeType, encoderOptions }).then(
-            (resized) => {
-                const { size } = new Blob([resized]);
+export const downSize = async (base64str, maxSize, mimeType = 'image/jpeg', encoderOptions = 1) => {
+    const process = async (source, maxWidth, maxHeight) => {
+        const resized = await resizeImage({
+            original: source,
+            maxWidth,
+            maxHeight,
+            finalMimeType: mimeType,
+            encoderOptions
+        });
+        const { size } = new Blob([resized]);
 
-                if (size <= maxSize) {
-                    return resized;
-                }
+        if (size <= maxSize) {
+            return resized;
+        }
 
-                return process(resized, Math.round(maxWidth * 0.9), Math.round(maxHeight * 0.9));
-            }
-        );
+        return process(resized, Math.round(maxWidth * 0.9), Math.round(maxHeight * 0.9));
     };
 
-    return toImage(base64str).then(({ height, width }) => process(base64str, width, height));
+    const { height, width } = await toImage(base64str);
+    return process(base64str, width, height);
 };
 
 /**

--- a/lib/helpers/image.js
+++ b/lib/helpers/image.js
@@ -19,23 +19,26 @@ export const toImage = (base64str) => {
 };
 
 /**
- * Resizes a picture to a maximum height/width (preserving height/width ratio)
+ * Resizes a picture to a maximum height/width (preserving height/width ratio). When both dimensions are specified,
+ * two resizes are possible: we pick the one with the bigger resize factor (so that both max dimensions are respected in the resized image)
  * @param {String} original Base64 representation of image to be resized.
  * @param {Number} maxWidth Maximum amount of pixels for the width of the resized image.
  * @param {Number} maxHeight Maximum amount of pixels for the height of the resized image
  * @param {String} finalMimeType Mime type of the resulting resized image.
  * @param {Number} encoderOptions A Number between 0 and 1 indicating image quality if the requested type is image/jpeg or image/webp
+ * @param {Boolean} bigResize If both maxHeight and maxWidth are specified, pick the smaller resize factor
  * @return {Promise} receives base64 string of resized image.
  *
  * @dev If maxWidth or maxHeight are equal to zero, the corresponding dimension is ignored
  */
-export const resizeImage = (
+export const resizeImage = ({
     original,
     maxWidth = 0,
     maxHeight = 0,
     finalMimeType = 'image/jpeg',
-    encoderOptions = 1
-) => {
+    encoderOptions = 1,
+    bigResize = false
+}) => {
     return toImage(original).then((image) => {
         // Resize the image
         const canvas = document.createElement('canvas');
@@ -43,14 +46,18 @@ export const resizeImage = (
 
         const [widthRatio, heightRatio] = [maxWidth && width / maxWidth, maxHeight && height / maxHeight].map(Number);
 
-        if (widthRatio >= heightRatio && widthRatio > 1) {
+        if (widthRatio <= 1 && heightRatio <= 1) {
+            return image.src;
+        }
+
+        const invert = maxWidth && maxHeight && bigResize;
+
+        if (widthRatio >= heightRatio === !invert) {
             height /= widthRatio;
             width = maxWidth;
-        } else if (heightRatio > 1) {
+        } else {
             width /= heightRatio;
             height = maxHeight;
-        } else {
-            return image.src;
         }
 
         canvas.width = width;
@@ -66,7 +73,7 @@ export const resizeImage = (
  * @param {String} str
  * @returns {Promise} {mime, base64}
  */
-const extractBase64Image = (str = '') => {
+export const extractBase64Image = (str = '') => {
     const [mimeInfo = '', base64 = ''] = (str || '').split(',');
     const [, mime = ''] = mimeInfo.match(/:(.*?);/) || [];
     return { mime, base64 };
@@ -118,15 +125,17 @@ export const toBlob = (base64str) => {
  */
 export const downSize = (base64str, maxSize, mimeType = 'image/jpeg', encoderOptions = 1) => {
     const process = (source, maxWidth, maxHeight) => {
-        return resizeImage(source, maxWidth, maxHeight, mimeType, encoderOptions).then((resized) => {
-            const { size } = new Blob([resized]);
+        return resizeImage({ original: source, maxWidth, maxHeight, finalMimeType: mimeType, encoderOptions }).then(
+            (resized) => {
+                const { size } = new Blob([resized]);
 
-            if (size <= maxSize) {
-                return resized;
+                if (size <= maxSize) {
+                    return resized;
+                }
+
+                return process(resized, Math.round(maxWidth * 0.9), Math.round(maxHeight * 0.9));
             }
-
-            return process(resized, Math.round(maxWidth * 0.9), Math.round(maxHeight * 0.9));
-        });
+        );
     };
 
     return toImage(base64str).then(({ height, width }) => process(base64str, width, height));

--- a/test/helpers/image.spec.js
+++ b/test/helpers/image.spec.js
@@ -30,58 +30,67 @@ describe('toFile', () => {
 
 describe('resizeImage', () => {
     it('it should be a string', async () => {
-        const base64str = await resizeImage(img, 100, 100);
+        const base64str = await resizeImage({ original: img, maxWidth: 100, maxHeight: 100 });
 
         expect(typeof base64str).toBe('string');
     });
 
     it('it should be shorter than the original if resized', async () => {
-        const base64str = await resizeImage(img, 100, 100);
+        const base64str = await resizeImage({ original: img, maxWidth: 100, maxHeight: 100 });
 
         expect(base64str.length).toBeLessThan(img.length);
     });
 
     it('it should not be resized if the resize parameters coincide with the original image size', async () => {
-        const base64str = await resizeImage(img, 300, 200);
+        const base64str = await resizeImage({ original: img, maxWidth: 300, maxHeight: 200 });
 
         expect(base64str.length).toBe(img.length);
     });
 
     it('it should not be resized if the width resize parameters is bigger than the original and the height is ignored', async () => {
-        const base64str = await resizeImage(img, 900);
+        const base64str = await resizeImage({ original: img, maxWidth: 900 });
 
         expect(base64str.length).toBe(img.length);
     });
 
     it('it should not be resized if the height resize parameters is bigger than the original and the width is ignored', async () => {
-        const base64str = await resizeImage(img, 0, 400);
+        const base64str = await resizeImage({ original: img, maxHeight: 400 });
 
         expect(base64str.length).toBe(img.length);
     });
 
     it('it should be a 64 string encoded', async () => {
-        const base64str = await resizeImage(img, 100, 100);
+        const base64str = await resizeImage({ original: img, maxWidth: 100, maxHeight: 100 });
 
         expect(typeof window.atob(base64str.replace('data:image/jpeg;base64,', ''))).toBe('string');
     });
 
     it('it should be respect the MIMEType set', async () => {
-        const base64str = await resizeImage(img, 100, 0, 'image/png');
+        const base64str = await resizeImage({ original: img, maxWidth: 100, finalMimeType: 'image/png' });
 
         expect(base64str.match(MIMETYPE_REGEX)[1]).toBe('image/png');
     });
 
     it('it should have a difference on image quality', async () => {
         const [base64str1, base64str2] = await Promise.all([
-            resizeImage(img, 100, 0, 'image/jpeg', 1),
-            resizeImage(img, 100, 0, 'image/jpeg', 0.1)
+            resizeImage({ original: img, maxWidth: 100, finalMimeType: 'image/jpeg', encoderOptions: 1 }),
+            resizeImage({ original: img, maxWidth: 100, finalMimeType: 'image/jpeg', encoderOptions: 0.1 })
+        ]);
+
+        expect(base64str1.length).toBeGreaterThan(base64str2.length);
+    });
+
+    it('it should resize to the bigger possibility when biggerResize is true', async () => {
+        const [base64str1, base64str2] = await Promise.all([
+            resizeImage({ original: img, maxWidth: 100, maxHeight: 100, bigResize: true }),
+            resizeImage({ original: img, maxWidth: 100, maxHeight: 100 })
         ]);
 
         expect(base64str1.length).toBeGreaterThan(base64str2.length);
     });
 
     it('it should be lighter than the original', async () => {
-        const base64str = await resizeImage(img, 100);
+        const base64str = await resizeImage({ original: img, maxWidth: 100 });
         const resizedFile = toFile(base64str, 'file1');
         const originalFile = toFile(img, 'file2');
 


### PR DESCRIPTION
I added a new parameter. When both `maxWidth` and `maxHeight` are specified, there are two resizes possible (resize so that `width = maxWidth` or `height = maxHeight`). By default, the function chooses the resize that will preserve `width <= maxWidth && height <= maxHeight`. But in some cases we may want to choose the "bigger" resize that will violate one of these conditions.

For the moment, this function is only used in `contacts`, where the PR https://github.com/ProtonMail/proton-contacts/pull/288 will take into account this new behavior.