### PR TITLE
Add helper for checking API responses when submitting arrays

### DIFF
--- a/lib/api/helpers/response.ts
+++ b/lib/api/helpers/response.ts
@@ -1,0 +1,19 @@
+import { API_CODES } from '../../constants';
+
+const { ARRAY_GLOBAL_SUCCESS, ARRAY_ELEMENT_SUCCESS } = API_CODES;
+
+interface Response {
+    Response: { Code: number };
+}
+
+interface Responses {
+    Code: number;
+    Responses?: Response[];
+}
+
+export const allSucceded = ({ Code, Responses = [] }: Responses): boolean => {
+    if (Code !== ARRAY_GLOBAL_SUCCESS) {
+        return false;
+    }
+    return !Responses.some(({ Response: { Code } }) => Code !== ARRAY_ELEMENT_SUCCESS);
+};

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,7 +15,7 @@ export enum APPS {
 export enum API_CODES {
     ARRAY_GLOBAL_SUCCESS = 1001,
     ARRAY_ELEMENT_SUCCESS = 1000
-}
+};
 export const MAIN_USER_KEY = 'USER_KEYS';
 export const SECURE_SESSION_STORAGE_KEY = 'SECURE';
 export const MAILBOX_PASSWORD_KEY = 'proton:mailbox_pwd';

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,6 +12,10 @@ export enum APPS {
     PROTONVPN_SETTINGS = 'proton-vpn-settings',
     PROTONADMIN = 'proton-admin'
 }
+export enum API_CODES {
+    ARRAY_GLOBAL_SUCCESS = 1001,
+    ARRAY_ELEMENT_SUCCESS = 1000
+}
 export const MAIN_USER_KEY = 'USER_KEYS';
 export const SECURE_SESSION_STORAGE_KEY = 'SECURE';
 export const MAILBOX_PASSWORD_KEY = 'proton:mailbox_pwd';

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,7 +15,7 @@ export enum APPS {
 export enum API_CODES {
     ARRAY_GLOBAL_SUCCESS = 1001,
     ARRAY_ELEMENT_SUCCESS = 1000
-};
+}
 export const MAIN_USER_KEY = 'USER_KEYS';
 export const SECURE_SESSION_STORAGE_KEY = 'SECURE';
 export const MAILBOX_PASSWORD_KEY = 'proton:mailbox_pwd';


### PR DESCRIPTION
When submitting arrays through POST/PUT/DELETE API routes, the response takes the generic form:
```
{
  "Code": 1001,
  "Responses": [
    {
      "Response": {
        "Code": 1000,
        ...
      },
      ...
    },
    ...
  ]
}
```
with the code `1000` when the corresponding element has been accepted by the API.

Here there is a helper to check if all elements in an array have been accepted by the API.