### PR TITLE
Rename api code constants

### DIFF
--- a/lib/api/helpers/response.ts
+++ b/lib/api/helpers/response.ts
@@ -1,6 +1,6 @@
 import { API_CODES } from '../../constants';
 
-const { ARRAY_GLOBAL_SUCCESS, ARRAY_ELEMENT_SUCCESS } = API_CODES;
+const { GLOBAL_SUCCESS, SINGLE_SUCCESS } = API_CODES;
 
 interface Response {
     Response: { Code: number };
@@ -12,8 +12,8 @@ interface Responses {
 }
 
 export const allSucceded = ({ Code, Responses = [] }: Responses): boolean => {
-    if (Code !== ARRAY_GLOBAL_SUCCESS) {
+    if (Code !== GLOBAL_SUCCESS) {
         return false;
     }
-    return !Responses.some(({ Response: { Code } }) => Code !== ARRAY_ELEMENT_SUCCESS);
+    return !Responses.some(({ Response: { Code } }) => Code !== SINGLE_SUCCESS);
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,8 +13,8 @@ export enum APPS {
     PROTONADMIN = 'proton-admin'
 }
 export enum API_CODES {
-    ARRAY_GLOBAL_SUCCESS = 1001,
-    ARRAY_ELEMENT_SUCCESS = 1000
+    GLOBAL_SUCCESS = 1001,
+    SINGLE_SUCCESS = 1000
 }
 export const MAIN_USER_KEY = 'USER_KEYS';
 export const SECURE_SESSION_STORAGE_KEY = 'SECURE';


### PR DESCRIPTION
The api codes in `constants` are not only used when arrays are submitted, so I think it's better to remove the reference to array in their names