### PR TITLE
Fix: using path to index label instead of name

### DIFF
--- a/lib/models/labelsModel.js
+++ b/lib/models/labelsModel.js
@@ -12,7 +12,7 @@ export const LabelsModel = {
     update: (model, events) => updateCollection({ model, events, item: ({ Label }) => Label })
 };
 
-const defaultMap = (label) => ({ key: label.Name, value: label });
+const defaultMap = (label) => ({ key: label.Path, value: label });
 
 export function factory(list = [], { formatMapLabel = defaultMap, formatMapFolder = defaultMap } = {}) {
     const { folders, labels, mapLabels, mapFolders } = list.reduce(


### PR DESCRIPTION
Filter Action Label should use the Path and not the Name.

This PR uses the Path as key in the labelsModel.mapLabels