### PR TITLE
fix(#63): Failed to construct 'URL'

### DIFF
--- a/lib/fetch/helpers.js
+++ b/lib/fetch/helpers.js
@@ -43,7 +43,7 @@ const appendQueryParams = (url, params) => {
  * @returns {URL}
  */
 export const createUrl = (urlString, params = {}) => {
-    const url = new URL(urlString);
+    const url = new URL(urlString, document.URL);
     appendQueryParams(url, params);
     return url;
 };

--- a/lib/fetch/helpers.js
+++ b/lib/fetch/helpers.js
@@ -43,7 +43,7 @@ const appendQueryParams = (url, params) => {
  * @returns {URL}
  */
 export const createUrl = (urlString, params = {}) => {
-    const url = new URL(urlString, document.URL);
+    const url = new URL(urlString, location.origin);
     appendQueryParams(url, params);
     return url;
 };


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/URL/URL

`url = new URL(url, [base])`
`url`
    A USVString representing an absolute or relative URL. If url is a relative URL, base is required, and will be used as the base URL. If url is an absolute URL, a given base will be ignored.