### PR TITLE
Sanitize condition values to remove nulls

### DIFF
--- a/lib/filters/factory.js
+++ b/lib/filters/factory.js
@@ -164,10 +164,15 @@ export function format(filter, mode) {
 
     // Order is always [<move-dir>, ...<add-labels>]
     const { FileInto = [], Labels = [] } = filter.Simple.Actions;
+
     const newFilter = {
         ...omit(filter, ['Sieve']),
         Simple: {
             ...filter.Simple,
+            Conditions: filter.Simple.Conditions.map((Condition) => ({
+                ...Condition,
+                Values: Condition.Values.filter((value) => value !== null)
+            })),
             Actions: {
                 ...omit(filter.Simple.Actions, 'Labels'),
                 FileInto: FileInto.concat(Labels)


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-mail-settings/issues/245

Needed a null value in the model to keep the last input open. Just filter it out at format time.