### PR TITLE
Promo end time based on absolute time stamp

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -268,7 +268,7 @@ export const BLACK_FRIDAY = {
         YEAR: 2019,
         MONTH: 11, // An integer between 0 (January) and 11 (December) representing the month
         DAY: 9,
-        HOUR: 7
+        HOUR: 8
     }
 };
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -256,20 +256,8 @@ export enum CYCLE {
 
 export const BLACK_FRIDAY = {
     COUPON_CODE: 'BF2019',
-    START: {
-        // Nov 26, 2019 06:00:00 UTC
-        YEAR: 2019,
-        MONTH: 10, // An integer between 0 (January) and 11 (December) representing the month
-        DAY: 26,
-        HOUR: 6
-    },
-    END: {
-        // Dec 9th 2019, 07:00:00 UTC
-        YEAR: 2019,
-        MONTH: 11, // An integer between 0 (January) and 11 (December) representing the month
-        DAY: 9,
-        HOUR: 8
-    }
+    START: new Date(Date.UTC(2019, 10, 26, 6)), // Nov 26, 2019 06:00:00 UTC
+    END: new Date(Date.UTC(2019, 11, 9, 8)) // Dec 9th 2019, 08:00:00 UTC
 };
 
 export const MIN_PAYPAL_AMOUNT = 500;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -256,8 +256,20 @@ export enum CYCLE {
 
 export const BLACK_FRIDAY = {
     COUPON_CODE: 'BF2019',
-    START: 'November 26, 2019 06:00:00',
-    END: '2019-12-09'
+    START: {
+        // Nov 26, 2019 06:00:00 UTC
+        YEAR: 2019,
+        MONTH: 10, // An integer between 0 (January) and 11 (December) representing the month
+        DAY: 26,
+        HOUR: 6
+    },
+    END: {
+        // Dec 9th 2019, 07:00:00 UTC
+        YEAR: 2019,
+        MONTH: 11, // An integer between 0 (January) and 11 (December) representing the month
+        DAY: 9,
+        HOUR: 7
+    }
 };
 
 export const MIN_PAYPAL_AMOUNT = 500;

--- a/lib/helpers/blackfriday.js
+++ b/lib/helpers/blackfriday.js
@@ -2,10 +2,15 @@ import { isWithinInterval, isAfter } from 'date-fns';
 
 import { BLACK_FRIDAY } from '../constants';
 
+const { START, END } = BLACK_FRIDAY;
+
+const START_DATE = new Date(Date.UTC(START.YEAR, START.MONTH, START.DAY, START.HOUR));
+const END_DATE = new Date(Date.UTC(END.YEAR, END.MONTH, END.DAY, END.HOUR));
+
 export const isBlackFridayPeriod = () => {
-    return isWithinInterval(new Date(), { start: new Date(BLACK_FRIDAY.START), end: new Date(BLACK_FRIDAY.END) });
+    return isWithinInterval(new Date(), { start: START_DATE, end: END_DATE });
 };
 
 export const isAfterBlackFriday = () => {
-    return isAfter(new Date(), new Date(BLACK_FRIDAY.END));
+    return isAfter(new Date(), END_DATE);
 };

--- a/lib/helpers/blackfriday.js
+++ b/lib/helpers/blackfriday.js
@@ -4,13 +4,10 @@ import { BLACK_FRIDAY } from '../constants';
 
 const { START, END } = BLACK_FRIDAY;
 
-const START_DATE = new Date(Date.UTC(START.YEAR, START.MONTH, START.DAY, START.HOUR));
-const END_DATE = new Date(Date.UTC(END.YEAR, END.MONTH, END.DAY, END.HOUR));
-
 export const isBlackFridayPeriod = () => {
-    return isWithinInterval(new Date(), { start: START_DATE, end: END_DATE });
+    return isWithinInterval(new Date(), { start: START, end: END });
 };
 
 export const isAfterBlackFriday = () => {
-    return isAfter(new Date(), END_DATE);
+    return isAfter(new Date(), END);
 };

--- a/lib/helpers/blackfriday.js
+++ b/lib/helpers/blackfriday.js
@@ -1,4 +1,4 @@
-import { isWithinInterval, isAfter } from 'date-fns';
+import { isWithinInterval, isAfter, isBefore } from 'date-fns';
 
 import { BLACK_FRIDAY } from '../constants';
 
@@ -10,4 +10,8 @@ export const isBlackFridayPeriod = () => {
 
 export const isAfterBlackFriday = () => {
     return isAfter(new Date(), END);
+};
+
+export const isBeforeBlackFriday = () => {
+    return isBefore(new Date(), START);
 };


### PR DESCRIPTION
- Use UTC start and end date for Black Friday promo.
- Manager Delong
- Fix https://gitlab.protontech.ch/ProtonVPN/web/protonvpn-settings/issues/48
- Test server https://vpnsettings.protonmail.blue