### PR TITLE
Fix alias timezones

### DIFF
--- a/lib/date/timezone.js
+++ b/lib/date/timezone.js
@@ -78,7 +78,7 @@ const guessTimezone = (timezones) => {
     try {
         const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
         // Ensure it exists.
-        return timezones.find((tz) => tz === timezone);
+        return findTimeZone(timezone).name;
     } catch (error) {
         const date = new Date();
         const timezoneOffset = date.getTimezoneOffset();


### PR DESCRIPTION
- [x] If the timezone detected by the browser is an [alias timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), guess the linked timezone.
- [ ] If the timezone detected is not supported by the browser, make an educated guess for an alternative.