### PR TITLE
openpgp message as stream and configuration per-project

### DIFF
--- a/lib/helpers/setupPmcrypto.js
+++ b/lib/helpers/setupPmcrypto.js
@@ -3,17 +3,20 @@ import { init, createWorker } from 'pmcrypto';
 
 import { loadScript } from './dom';
 
-export const initMain = async (openpgpContents, ellipticOptions) => {
+export const initMain = async (openpgpContents, ellipticOptions, openpgpConfig = {}) => {
     const mainUrl = URL.createObjectURL(new Blob([openpgpContents], { type: 'text/javascript' }));
     await loadScript(mainUrl);
     URL.revokeObjectURL(mainUrl);
 
-    window.openpgp.config.allow_unauthenticated_stream = true;
     window.openpgp.config.indutny_elliptic_path = `${window.location.origin}${ellipticOptions.filepath}`;
     window.openpgp.config.indutny_elliptic_fetch_options = {
         integrity: ellipticOptions.integrity,
         credentials: 'same-origin'
     };
+
+    Object.entries(openpgpConfig).forEach(([key, value]) => {
+        window.openpgp.config[key] = value;
+    });
 
     init(window.openpgp);
 };

--- a/lib/helpers/setupPmcrypto.js
+++ b/lib/helpers/setupPmcrypto.js
@@ -8,6 +8,7 @@ export const initMain = async (openpgpContents, ellipticOptions) => {
     await loadScript(mainUrl);
     URL.revokeObjectURL(mainUrl);
 
+    window.openpgp.config.allow_unauthenticated_stream = true;
     window.openpgp.config.indutny_elliptic_path = `${window.location.origin}${ellipticOptions.filepath}`;
     window.openpgp.config.indutny_elliptic_fetch_options = {
         integrity: ellipticOptions.integrity,

--- a/lib/keys/driveKeys.ts
+++ b/lib/keys/driveKeys.ts
@@ -1,7 +1,12 @@
-import { decryptMessage, getMessage, encryptMessage, generateKey } from 'pmcrypto/lib/pmcrypto';
 import { key } from 'openpgp';
+import { decryptMessage, getMessage, encryptMessage, generateKey } from 'pmcrypto/lib/pmcrypto';
+import { openpgp } from 'pmcrypto/lib/openpgp';
+import { ReadableStream as PolyfillReadableStream } from 'web-streams-polyfill';
+import { createReadableStreamWrapper } from '@mattiasbuelens/web-streams-adapter';
 import { ENCRYPTION_CONFIGS, ENCRYPTION_TYPES } from '../constants';
 import { generatePassphrase } from './calendarKeys';
+
+const toPolyfillReadable = createReadableStreamWrapper(PolyfillReadableStream);
 
 interface UnsignedEncryptionPayload {
     message: string;
@@ -21,6 +26,10 @@ interface UnsignedDecryptionPayload {
     armoredMessage: string | Uint8Array;
     privateKey: key.Key;
 }
+
+export const getStreamMessage = (stream: ReadableStream<Uint8Array>) => {
+    return openpgp.message.read(toPolyfillReadable(stream));
+};
 
 /**
  * Decrypts unsigned armored message, in the context of drive it's share's passphrase and folder's contents.

--- a/lib/openpgp.js
+++ b/lib/openpgp.js
@@ -24,7 +24,7 @@ const isUnsupportedWorker = () => {
  * Initialize openpgp
  * @return {Promise}
  */
-export const init = async () => {
+export const init = async (openpgpConfig) => {
     // PM_OPENPGP is set from webpack
     // eslint-disable-next-line no-undef
     const { main, compat, elliptic, worker } = PM_OPENPGP;
@@ -38,7 +38,7 @@ export const init = async () => {
     const workerPromise = dl(worker).catch(() => dl(worker));
 
     const openpgpContents = await openpgpPromise;
-    await initMain(openpgpContents, elliptic);
+    await initMain(openpgpContents, elliptic, openpgpConfig);
 
     // Compat browsers do not support the worker.
     if (isCompat || isUnsupportedWorker()) {
@@ -57,7 +57,7 @@ let promise;
  * Get the openpgp init promise singleton
  * @return {Promise}
  */
-export const loadOpenPGP = () => {
+export const loadOpenPGP = (openpgpConfig) => {
     // eslint-disable-next-line no-return-assign
-    return promise || (promise = init());
+    return promise || (promise = init(openpgpConfig));
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/ProtonMail/proton-shared#readme",
   "dependencies": {
+    "@mattiasbuelens/web-streams-adapter": "0.1.0-alpha.3",
     "@sentry/browser": "^5.6.2",
     "@types/node": "^12.7.11",
     "@types/openpgp": "^4.4.7",
@@ -42,15 +43,16 @@
     "dompurify": "^2.0.7",
     "file-saver": "^2.0.2",
     "get-random-values": "github:ProtonMail/get-random-values#semver:^1.0.0",
-    "pmcrypto": "github:ProtonMail/pmcrypto.git#semver:~6.2.0",
-    "pm-srp": "github:ProtonMail/pm-srp.git#semver:^1.0.0",
     "hi-base32": "^0.5.0",
     "ical.js": "^1.3.0",
     "lodash": "^4.17.11",
+    "pm-srp": "github:ProtonMail/pm-srp.git#semver:^1.0.0",
+    "pmcrypto": "github:ProtonMail/pmcrypto.git#semver:~6.2.0",
     "push.js": "^1.0.12",
     "sieve.js": "github:ProtonMail/sieve.js#master",
     "timezone-support": "github:ProtonMail/timezone-support#bundle",
-    "ua-parser-js": "^0.7.20"
+    "ua-parser-js": "^0.7.20",
+    "web-streams-polyfill": "^2.0.6"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.6.2",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'pmcrypto/lib/openpgp' {
+    const openpgp: any;
+    export { openpgp };
+}


### PR DESCRIPTION
Open pgp uses a polyfill internally, so at the moment I need to convert any native implementation to the polyfill so that it's recognized as stream by openpgp.message.read().