### PR TITLE
Encryption functions for drive upload

### DIFF
--- a/lib/fetch/helpers.js
+++ b/lib/fetch/helpers.js
@@ -137,5 +137,13 @@ export const serializeData = (data, input) => {
             body: serializeFormData(data)
         };
     }
+    if (input === 'binary') {
+        return {
+            body: data,
+            headers: {
+                'Content-Type': 'application/x-binary'
+            }
+        };
+    }
     return {};
 };

--- a/lib/keys/driveKeys.ts
+++ b/lib/keys/driveKeys.ts
@@ -86,8 +86,12 @@ export const generateLookupHash = async (name: string, hashKey: string) => {
         ['sign', 'verify']
     );
 
-    const data = binaryStringToArray(name).buffer;
-    return arrayToHexString(new Uint8Array(await crypto.subtle.sign('HMAC', key, data)));
+    const signature = await crypto.subtle.sign(
+        { name: 'HMAC', hash: { name: 'SHA-256' } },
+        key,
+        binaryStringToArray(name)
+    );
+    return arrayToHexString(new Uint8Array(signature));
 };
 
 export const generateNodeHashKey = async (privateKey: key.Key) => {

--- a/lib/keys/driveKeys.ts
+++ b/lib/keys/driveKeys.ts
@@ -1,10 +1,20 @@
 import { key } from 'openpgp';
-import { decryptMessage, getMessage, encryptMessage, generateKey } from 'pmcrypto/lib/pmcrypto';
+import {
+    decryptMessage,
+    getMessage,
+    encryptMessage,
+    generateKey,
+    binaryStringToArray,
+    arrayToHexString,
+    signMessage
+} from 'pmcrypto/lib/pmcrypto';
 import { openpgp } from 'pmcrypto/lib/openpgp';
 import { ReadableStream as PolyfillReadableStream } from 'web-streams-polyfill';
 import { createReadableStreamWrapper } from '@mattiasbuelens/web-streams-adapter';
 import { ENCRYPTION_CONFIGS, ENCRYPTION_TYPES } from '../constants';
 import { generatePassphrase } from './calendarKeys';
+import { createSessionKey, getEncryptedSessionKey } from '../calendar/encrypt';
+import { serializeUint8Array } from '../helpers/serialization';
 
 const toPolyfillReadable = createReadableStreamWrapper(PolyfillReadableStream);
 
@@ -12,6 +22,16 @@ interface UnsignedEncryptionPayload {
     message: string;
     privateKey: key.Key;
 }
+
+export const sign = async (data: string, privateKeys: key.Key | key.Key[]) => {
+    const { signature } = await signMessage({
+        data,
+        privateKeys,
+        armor: true,
+        detached: true
+    });
+    return signature;
+};
 
 export const encryptUnsigned = async ({ message, privateKey }: UnsignedEncryptionPayload) => {
     const { data: encryptedToken } = await encryptMessage({
@@ -57,36 +77,79 @@ export const generateDriveKey = async (rawPassphrase: string) => {
     return { privateKey, privateKeyArmored };
 };
 
+export const generateLookupHash = async (name: string, hashKey: string) => {
+    const key = await crypto.subtle.importKey(
+        'raw',
+        binaryStringToArray(hashKey),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign', 'verify']
+    );
+
+    const data = binaryStringToArray(name).buffer;
+    return arrayToHexString(new Uint8Array(await crypto.subtle.sign('HMAC', key, data)));
+};
+
+export const generateNodeHashKey = async (privateKey: key.Key) => {
+    const message = generatePassphrase();
+
+    const NodeHashKey = await encryptUnsigned({
+        message,
+        privateKey
+    });
+
+    return { NodeHashKey };
+};
+
+export const generateNodeKeys = async (parentKey: key.Key) => {
+    const rawPassphrase = generatePassphrase();
+    const { privateKey, privateKeyArmored: NodeKey } = await generateDriveKey(rawPassphrase);
+
+    const NodePassphrase = await encryptUnsigned({
+        message: rawPassphrase,
+        privateKey: parentKey
+    });
+
+    return { privateKey, NodeKey, NodePassphrase, rawPassphrase };
+};
+
+export const generateContentHash = async (content: Uint8Array) => {
+    const data = await openpgp.crypto.hash.sha256(content);
+    return { HashType: 'sha256', BlockHash: arrayToHexString(data) as string };
+};
+
+export const generateContentKeys = async (nodeKey: key.Key) => {
+    const publicKey = nodeKey.toPublic();
+    const sessionKey = await createSessionKey(publicKey);
+    const contentKeys = await getEncryptedSessionKey(sessionKey, publicKey);
+    const ContentKeyPacket = serializeUint8Array(contentKeys);
+    return { sessionKey, ContentKeyPacket };
+};
+
 export const generateDriveBootstrap = async (addressPrivateKey: key.Key) => {
-    const rawSharePassphrase = generatePassphrase();
-    const rawFolderPassphrase = generatePassphrase();
+    const { NodeKey: ShareKey, NodePassphrase: SharePassphrase, privateKey: sharePrivateKey } = await generateNodeKeys(
+        addressPrivateKey
+    );
 
-    const [
-        { privateKey: sharePrivateKey, privateKeyArmored: ShareKey },
-        { privateKey: folderPrivateKey, privateKeyArmored: FolderKey },
-        SharePassphrase
-    ] = await Promise.all([
-        generateDriveKey(rawSharePassphrase),
-        generateDriveKey(rawFolderPassphrase),
-        encryptUnsigned({ message: rawSharePassphrase, privateKey: addressPrivateKey })
-    ]);
+    const {
+        NodeKey: FolderKey,
+        NodePassphrase: FolderPassphrase,
+        privateKey: folderPrivateKey
+    } = await generateNodeKeys(sharePrivateKey);
 
-    const [FolderPassphrase, FolderName] = await Promise.all([
-        await encryptUnsigned({
-            message: rawFolderPassphrase,
-            privateKey: sharePrivateKey
-        }),
-        await encryptUnsigned({
-            message: 'root',
-            privateKey: folderPrivateKey
-        })
-    ]);
+    const FolderName = await encryptUnsigned({
+        message: 'root',
+        privateKey: folderPrivateKey
+    });
 
     return {
-        SharePassphrase,
-        FolderPassphrase,
-        ShareKey,
-        FolderKey,
-        FolderName
+        bootstrap: {
+            SharePassphrase,
+            FolderPassphrase,
+            ShareKey,
+            FolderKey,
+            FolderName
+        },
+        sharePrivateKey
     };
 };


### PR DESCRIPTION
Blocks are sent using `x-binary` content type, so that backend api doesn't serialize it as json. Form data did not work for them for some reason. 