### PR TITLE
Fix/unload to pagehide

### DIFF
--- a/lib/helpers/dom.js
+++ b/lib/helpers/dom.js
@@ -1,6 +1,8 @@
 export const attachOnUnload = (cb) => {
     if (window.addEventListener) {
-        return window.addEventListener('unload', cb, false);
+        // eslint-disable-next-line no-restricted-globals
+        const terminationEvent = 'onpagehide' in self ? 'pagehide' : 'unload';
+        return window.addEventListener(terminationEvent, cb, { capture: true });
     }
 
     if (window.attachEvent) {

--- a/lib/helpers/dom.js
+++ b/lib/helpers/dom.js
@@ -2,7 +2,7 @@ export const attachOnUnload = (cb) => {
     if (window.addEventListener) {
         // eslint-disable-next-line no-restricted-globals
         const terminationEvent = 'onpagehide' in self ? 'pagehide' : 'unload';
-        return window.addEventListener(terminationEvent, cb, { capture: true });
+        return window.addEventListener(terminationEvent, cb, true);
     }
 
     if (window.attachEvent) {


### PR DESCRIPTION
According to https://developers.google.com/web/updates/2018/07/page-lifecycle-api unload is more or less deprecated. Pagehide can be used instead. This fixes https://github.com/ProtonMail/Angular/issues/9354 (and the angular project needs a separate pr)