### PR TITLE
Adjust typecheck depth for proton-shared

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-    "extends": "./tsconfig.base.json"
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "maxNodeModuleJsDepth": 0
+    }
 }


### PR DESCRIPTION
It seems that openpgp's dependencies have poor typings. This should reduce the depth of typechecking from js files in proton-shared. Other projects should not be affected.

Fixes CI build errors.