### PR TITLE
More tests for get milliseconds from trigger string

### DIFF
--- a/test/calendar/vcal.spec.js
+++ b/test/calendar/vcal.spec.js
@@ -1,5 +1,5 @@
 import { parse, fromTriggerString, serialize, getMillisecondsFromTriggerString } from '../../lib/calendar/vcal';
-import { HOUR, MINUTE, SECOND } from '../../lib/constants';
+import { WEEK, DAY, HOUR, MINUTE, SECOND } from '../../lib/constants';
 
 const vevent = `BEGIN:VEVENT
 DTSTAMP:20190719T130854Z
@@ -256,6 +256,8 @@ describe('calendar', () => {
     it('should convert trigger strings into milliseconds', () => {
         expect(getMillisecondsFromTriggerString('-PT30M')).toEqual(-30 * MINUTE);
         expect(getMillisecondsFromTriggerString('PT1H')).toEqual(HOUR);
+        expect(getMillisecondsFromTriggerString('P1D')).toEqual(DAY);
         expect(getMillisecondsFromTriggerString('-PT2H34M12S')).toEqual(-2 * HOUR - 34 * MINUTE - 12 * SECOND);
+        expect(getMillisecondsFromTriggerString('P2W1DT1S')).toEqual(2 * WEEK + DAY + SECOND);
     });
 });

--- a/test/calendar/vcal.spec.js
+++ b/test/calendar/vcal.spec.js
@@ -256,7 +256,7 @@ describe('calendar', () => {
     it('should convert trigger strings into milliseconds', () => {
         expect(getMillisecondsFromTriggerString('-PT30M')).toEqual(-30 * MINUTE);
         expect(getMillisecondsFromTriggerString('PT1H')).toEqual(HOUR);
-        expect(getMillisecondsFromTriggerString('P1D')).toEqual(DAY);
+        expect(getMillisecondsFromTriggerString('-P1D')).toEqual(-DAY);
         expect(getMillisecondsFromTriggerString('-PT2H34M12S')).toEqual(-2 * HOUR - 34 * MINUTE - 12 * SECOND);
         expect(getMillisecondsFromTriggerString('P2W1DT1S')).toEqual(2 * WEEK + DAY + SECOND);
     });


### PR DESCRIPTION
A couple of types of trigger strings (involving weeks and days) were not tested