### PR TITLE
External images could not be manipulated

### DIFF
--- a/lib/helpers/image.js
+++ b/lib/helpers/image.js
@@ -17,6 +17,14 @@ export const toImage = (url) => {
         };
         image.onerror = reject;
 
+        /**
+         * allow external images to be used in a canvas as if they were loaded
+         * from the current origin without sending any user credentials.
+         * (otherwise canvas.toDataURL in resizeImage will throw complaining that the canvas is tainted)
+         * An error will be thrown if the requested resource hasn't specified an appropriate CORS policy
+         * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+         */
+        image.crossOrigin = 'anonymous';
         image.src = url;
     });
 };

--- a/lib/helpers/image.js
+++ b/lib/helpers/image.js
@@ -25,6 +25,7 @@ export const toImage = (url) => {
          * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
          */
         image.crossOrigin = 'anonymous';
+        image.referrerPolicy = 'no-referrer';
         image.src = url;
     });
 };


### PR DESCRIPTION
We were not specifying the `crossOrigin` attribute in image elements that could take an external url as source. In those cases, some of the canvas methods (in particular 'canvas.getContext('2d').toDataURL`) do not work (see https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image). For instance we could not resize it.