### PR TITLE
Fix isUTC and UTC timezone

### DIFF
--- a/lib/calendar/vcal.js
+++ b/lib/calendar/vcal.js
@@ -227,6 +227,36 @@ const getParameters = (type, property) => {
     return result;
 };
 
+const modifyInternalObject = (type, internalObject) => {
+    if (type === 'date-time') {
+        const { value, parameters } = internalObject;
+        // eslint-disable-next-line no-mixed-operators
+        const tzid = (parameters && parameters.tzid) || '';
+        if (tzid.toLowerCase().includes('utc')) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { tzid: omitTzid, ...restParameters } = parameters;
+            return {
+                value: { ...value, isUTC: true },
+                ...(Object.keys(restParameters).length && { parameters: restParameters })
+            };
+        }
+        return internalObject;
+    }
+    return internalObject;
+};
+
+const propertyToObject = (property) => {
+    const { type } = property;
+
+    const values = property.getValues().map((value) => icalValueToInternalValue(type, value));
+    const parameters = getParameters(type, property);
+
+    return modifyInternalObject(type, {
+        value: property.isMultiValue ? values : values[0],
+        ...(Object.keys(parameters).length && { parameters })
+    });
+};
+
 /**
  * @param {Array} properties
  * @return {Object}
@@ -242,14 +272,7 @@ const fromIcalProperties = (properties = []) => {
             return acc;
         }
 
-        const { type } = property;
-        const values = property.getValues().map((value) => icalValueToInternalValue(type, value));
-
-        const parameters = getParameters(type, property);
-        const propertyAsObject = {
-            value: property.isMultiValue ? values : values[0],
-            ...(Object.keys(parameters).length && { parameters })
-        };
+        const propertyAsObject = propertyToObject(property);
 
         if (PROPERTIES[name] === UNIQUE) {
             acc[name] = propertyAsObject;

--- a/test/calendar/vcal.spec.js
+++ b/test/calendar/vcal.spec.js
@@ -101,6 +101,11 @@ END:VEVENT`;
 
 const veventsRruleYearly = [veventRruleYearly];
 
+const veventUTC = `BEGIN:VEVENT
+DTSTART;TZID=Etc/UTC:20190101T000000
+DTEND;TZID=UTC:20190101T020000
+END:VEVENT`;
+
 describe('calendar', () => {
     it('should parse vevent', () => {
         const result = parse(vevent);
@@ -414,6 +419,20 @@ describe('calendar', () => {
     it('should round trip all day vevent', () => {
         const result = serialize(parse(allDayVevent));
         expect(trimAll(result)).toEqual(trimAll(allDayVevent));
+    });
+
+    fit('should parse vevent with UTC timezone without appending tzid UTC', () => {
+        const result = parse(veventUTC);
+
+        expect(result).toEqual({
+            component: 'vevent',
+            dtstart: {
+                value: { year: 2019, month: 1, day: 1, hours: 0, minutes: 0, seconds: 0, isUTC: true }
+            },
+            dtend: {
+                value: { year: 2019, month: 1, day: 1, hours: 2, minutes: 0, seconds: 0, isUTC: true }
+            }
+        });
     });
 
     it('should parse trigger string', () => {


### PR DESCRIPTION

Turns out that 

```BEGIN:VEVENT
DTSTART;TZID=Etc/UTC:20190101T000000
DTEND;TZID=UTC:20190101T020000
END:VEVENT```

Would get parsed as:

```
{
            component: 'vevent',
            dtstart: {
                value: { year: 2019, month: 1, day: 1, hours: 0, minutes: 0, seconds: 0, isUTC: false },
                parameters: { tzid: 'Etc/UTC' }
            },
            dtend: {
                value: { year: 2019, month: 1, day: 1, hours: 2, minutes: 0, seconds: 0, isUTC: true },
                parameters: { tzid: 'UTC' }
            }
        }
```

Which would make some of the places were we're checking !tzid unneccessarily convert to UTC to UTC. Not sure if this PR is worth it.