### PR TITLE
Add unit tests for date.ts

### DIFF
--- a/lib/date/date.ts
+++ b/lib/date/date.ts
@@ -21,6 +21,7 @@ export const getFormattedWeekdays = (stringFormat: string, options?: FormatOptio
 export const getFormattedMonths = (stringFormat: string, options?: FormatOptions) => {
     const dummyDate = startOfYear(new Date(0));
     const dummyMonths = Array.from({ length: 12 }).map((_, i) => addMonths(dummyDate, i));
+
     return dummyMonths.map((date) => format(date, stringFormat, options));
 };
 

--- a/test/date/date.spec.ts
+++ b/test/date/date.spec.ts
@@ -1,0 +1,74 @@
+import { enUS, fr } from 'date-fns/locale';
+import { getFormattedWeekdays, getFormattedMonths, getWeekStartsOn } from '../../lib/date/date';
+
+describe('getFormattedWeekdays', () => {
+    it('should get a list with the names of the days of the week according to current locale', () => {
+        expect(getFormattedWeekdays('cccc', { locale: enUS })).toEqual([
+            'Sunday',
+            'Monday',
+            'Tuesday',
+            'Wednesday',
+            'Thursday',
+            'Friday',
+            'Saturday'
+        ]);
+        expect(getFormattedWeekdays('cccc', { locale: fr })).toEqual([
+            'dimanche',
+            'lundi',
+            'mardi',
+            'mercredi',
+            'jeudi',
+            'vendredi',
+            'samedi'
+        ]);
+        expect(getFormattedWeekdays('cccc', { locale: fr, weekStartsOn: 1 })).toEqual([
+            'dimanche',
+            'lundi',
+            'mardi',
+            'mercredi',
+            'jeudi',
+            'vendredi',
+            'samedi'
+        ]);
+    });
+});
+
+describe('getFormattedMonths', () => {
+    it('should get a list with the names of the days of the week according to current locale', () => {
+        expect(getFormattedMonths('MMMM', { locale: enUS })).toEqual([
+            'January',
+            'February',
+            'March',
+            'April',
+            'May',
+            'June',
+            'July',
+            'August',
+            'September',
+            'October',
+            'November',
+            'December'
+        ]);
+        expect(getFormattedMonths('MMMM', { locale: fr })).toEqual([
+            'janvier',
+            'février',
+            'mars',
+            'avril',
+            'mai',
+            'juin',
+            'juillet',
+            'août',
+            'septembre',
+            'octobre',
+            'novembre',
+            'décembre'
+        ]);
+    });
+});
+
+describe('getWeekStartsOn', () => {
+    it('should get a list with the names of the days of the week according to current locale', () => {
+        expect(getWeekStartsOn(enUS)).toEqual(0);
+        expect(getWeekStartsOn(fr)).toEqual(1);
+    });
+});


### PR DESCRIPTION
Hi,

When reading `FormatOptions`  with `locale` and `weekStartsOn` then used as `options` for `getFormattedWeekdays()` I was guessing it would use first `weekStartsOn` then `options.weekStartsOn` from the locale (what `according to current locale` in the JSDoc begin tends to confirm).

Then as the end of the JSDoc says `where Sunday is the start of the week`, I was not so sure. As `startOfWeek` and `endOfWeek` does not take any options, it would imply that `weekStartsOn` from  `FormatOptions` (as the option of the locale) are simply ignored. So I covered the file with some tests.

It confirmed the last hypothesis which leads me to think:
- Either `weekStartsOn` should be removed from `FormatOptions` as it's never used to avoid a misleading typehint. And the JSDoc may precise `in the language given by the locale` to specify only the language is used (as locale is language settings + localization settings such as date/time formatting, start of week, and many options that may be expected to be taken into account when speaking of "locale")
- Or `{ start: startOfWeek(zeroTime, options), end: endOfWeek(zeroTime, options) }` should be used to make `weekStartsOn` and locale options actually used. So the first day would become "dimanche" in unit tests for `fr` locale. And so `where Sunday is the start of the week` would be removed from the JSDoc.

The second option would be my favorite even if it's a BC (would need a major version bump) as I would feel natural to get Monday as the first day of week when giving the "fr" locale (shorthand for "fr_FR" = France region which uses Monday as start of week.

The both option for backward-compatibility could be

If you wish, I would be happy to proceed one or the other change in this PR, or in a second PR if you like first to merge those unit tests as is.

Thanks,