### PR TITLE
Remove unused weekStartsOn option

### DIFF
--- a/lib/date/date.ts
+++ b/lib/date/date.ts
@@ -2,7 +2,6 @@ import { eachDayOfInterval, startOfWeek, endOfWeek, startOfYear, format, addMont
 
 interface FormatOptions {
     locale?: Locale;
-    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 /**

--- a/test/date/date.spec.ts
+++ b/test/date/date.spec.ts
@@ -21,20 +21,11 @@ describe('getFormattedWeekdays', () => {
             'vendredi',
             'samedi'
         ]);
-        expect(getFormattedWeekdays('cccc', { locale: fr, weekStartsOn: 1 })).toEqual([
-            'dimanche',
-            'lundi',
-            'mardi',
-            'mercredi',
-            'jeudi',
-            'vendredi',
-            'samedi'
-        ]);
     });
 });
 
 describe('getFormattedMonths', () => {
-    it('should get a list with the names of the days of the week according to current locale', () => {
+    it('should get a list with the names of the months of the year according to current locale', () => {
         expect(getFormattedMonths('MMMM', { locale: enUS })).toEqual([
             'January',
             'February',
@@ -67,7 +58,7 @@ describe('getFormattedMonths', () => {
 });
 
 describe('getWeekStartsOn', () => {
-    it('should get a list with the names of the days of the week according to current locale', () => {
+    it('should get a index from 0 (Sunday) to 6 (Saturday) of the first day of week of a given locale', () => {
         expect(getWeekStartsOn(enUS)).toEqual(0);
         expect(getWeekStartsOn(fr)).toEqual(1);
     });


### PR DESCRIPTION
This is a breaking change in the consideration of the typing if we assume users passed explicitly the `weekStartsOn` option despite it does not change the result.

So I would say pragmatically, this BC is very-low impact.

But if you prefer, I could use a deprecation annotation instead.

Else I also fixed the tests messages.